### PR TITLE
Move modifiers to info1 field, add tooltip

### DIFF
--- a/languages/de.json
+++ b/languages/de.json
@@ -1,8 +1,4 @@
 {
-    "tokenActionHud.shadowdark.setting.showAttackBonus.hint": "Show roll bonus for attacks",
-    "tokenActionHud.shadowdark.setting.showAttackBonus.name": "Show Roll Bonus for Attacks",
-    "tokenActionHud.shadowdark.setting.showAbilityBonus.hint": "Show roll bonus for abilities",
-    "tokenActionHud.shadowdark.setting.showAbilityBonus.name": "Show Roll Bonus for Abilities",
     "tokenActionHud.shadowdark.setting.showAttackRanges.hint": "Show range icons for attacks",
     "tokenActionHud.shadowdark.setting.showAttackRanges.name": "Show Range Icons for Attacks",
     "tokenActionHud.shadowdark.setting.showSpellRanges.hint": "Show Range Icons for Spells",

--- a/languages/en.json
+++ b/languages/en.json
@@ -1,8 +1,4 @@
 {
-	"tokenActionHud.shadowdark.setting.showAttackBonus.hint": "Show roll bonus for attacks",
-	"tokenActionHud.shadowdark.setting.showAttackBonus.name": "Show Roll Bonus for Attacks",
-	"tokenActionHud.shadowdark.setting.showAbilityBonus.hint": "Show roll bonus for abilities",
-	"tokenActionHud.shadowdark.setting.showAbilityBonus.name": "Show Roll Bonus for Abilities",
 	"tokenActionHud.shadowdark.setting.showAttackRanges.hint": "Show range icons for attacks",
 	"tokenActionHud.shadowdark.setting.showAttackRanges.name": "Show Range Icons for Attacks",
 	"tokenActionHud.shadowdark.setting.showSpellRanges.hint": "Show Range Icons for Spells",

--- a/languages/es.json
+++ b/languages/es.json
@@ -1,8 +1,4 @@
 {
-    "tokenActionHud.shadowdark.setting.showAttackBonus.hint": "Mostrar bonus de tirada para ataques",
-    "tokenActionHud.shadowdark.setting.showAttackBonus.name": "Mostrar bonus de tirada para ataques",
-    "tokenActionHud.shadowdark.setting.showAbilityBonus.hint": "Mostrar bonus de tiro para habilidades",
-    "tokenActionHud.shadowdark.setting.showAbilityBonus.name": "Mostrar bonus de tiro para habilidades",
     "tokenActionHud.shadowdark.setting.showAttackRanges.hint": "Mostrar iconos de rangos de ataques",
     "tokenActionHud.shadowdark.setting.showAttackRanges.name": "Mostrar iconos de rangos de ataques",
     "tokenActionHud.shadowdark.setting.showSpellRanges.hint": "Mostrar iconos de rangos de hechizos",

--- a/languages/fi.json
+++ b/languages/fi.json
@@ -1,8 +1,4 @@
 {
-    "tokenActionHud.shadowdark.setting.showAttackBonus.hint": "Show roll bonus for attacks",
-    "tokenActionHud.shadowdark.setting.showAttackBonus.name": "Show Roll Bonus for Attacks",
-    "tokenActionHud.shadowdark.setting.showAbilityBonus.hint": "Show roll bonus for abilities",
-    "tokenActionHud.shadowdark.setting.showAbilityBonus.name": "Show Roll Bonus for Abilities",
     "tokenActionHud.shadowdark.setting.showAttackRanges.hint": "Show range icons for attacks",
     "tokenActionHud.shadowdark.setting.showAttackRanges.name": "Show Range Icons for Attacks",
     "tokenActionHud.shadowdark.setting.showSpellRanges.hint": "Show Range Icons for Spells",

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -1,8 +1,4 @@
 {
-    "tokenActionHud.shadowdark.setting.showAttackBonus.hint": "Show roll bonus for attacks",
-    "tokenActionHud.shadowdark.setting.showAttackBonus.name": "Show Roll Bonus for Attacks",
-    "tokenActionHud.shadowdark.setting.showAbilityBonus.hint": "Show roll bonus for abilities",
-    "tokenActionHud.shadowdark.setting.showAbilityBonus.name": "Show Roll Bonus for Abilities",
     "tokenActionHud.shadowdark.setting.showAttackRanges.hint": "Show range icons for attacks",
     "tokenActionHud.shadowdark.setting.showAttackRanges.name": "Show Range Icons for Attacks",
     "tokenActionHud.shadowdark.setting.showSpellRanges.hint": "Show Range Icons for Spells",

--- a/languages/ko.json
+++ b/languages/ko.json
@@ -1,8 +1,4 @@
 {
-    "tokenActionHud.shadowdark.setting.showAttackBonus.hint": "Show roll bonus for attacks",
-    "tokenActionHud.shadowdark.setting.showAttackBonus.name": "Show Roll Bonus for Attacks",
-    "tokenActionHud.shadowdark.setting.showAbilityBonus.hint": "Show roll bonus for abilities",
-    "tokenActionHud.shadowdark.setting.showAbilityBonus.name": "Show Roll Bonus for Abilities",
     "tokenActionHud.shadowdark.setting.showAttackRanges.hint": "Show range icons for attacks",
     "tokenActionHud.shadowdark.setting.showAttackRanges.name": "Show Range Icons for Attacks",
     "tokenActionHud.shadowdark.setting.showSpellRanges.hint": "Show Range Icons for Spells",

--- a/languages/sv.json
+++ b/languages/sv.json
@@ -1,8 +1,4 @@
 {
-    "tokenActionHud.shadowdark.setting.showAttackBonus.hint": "Show roll bonus for attacks",
-    "tokenActionHud.shadowdark.setting.showAttackBonus.name": "Show Roll Bonus for Attacks",
-    "tokenActionHud.shadowdark.setting.showAbilityBonus.hint": "Show roll bonus for abilities",
-    "tokenActionHud.shadowdark.setting.showAbilityBonus.name": "Show Roll Bonus for Abilities",
     "tokenActionHud.shadowdark.setting.showAttackRanges.hint": "Show range icons for attacks",
     "tokenActionHud.shadowdark.setting.showAttackRanges.name": "Show Range Icons for Attacks",
     "tokenActionHud.shadowdark.setting.showSpellRanges.hint": "Show Range Icons for Spells",

--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -416,7 +416,6 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
         async #buildClassAbilities () {
             const actionType = 'classAbility'
             const classAbilities = this.actor?.itemTypes['Class Ability']
-            console.log(classAbilities)
 
             if (classAbilities.length > 0) {
                 const activeGroups = [...new Set(classAbilities.map(item => item.system.group))]

--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 // System Module Imports
-import { ACTION_TYPE, ABILITY, GROUP, ICON } from './constants.js'
+import { ACTION_TYPE, GROUP, ICON } from './constants.js'
 import { Utils } from './utils.js'
 
 export let ActionHandler = null
@@ -173,11 +173,11 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                         weaponMasterBonus
                     meleeAttackActions.push(
                         new Action(attack, actionType, {
-                            name:
-                                attack.name +
-                                (this.showAttackBonus
-                                    ? getBonusString(meleeAttackBonus)
-                                    : ''),
+                            name: attack.name,
+                            info1: this.showAttackBonus ? {
+                                text: coreModule.api.Utils.getModifier(meleeAttackBonus),
+                                title: `${game.i18n.localize("SHADOWDARK.item.effect.predefined_effect.meleeAttackBonus")}: ${coreModule.api.Utils.getModifier(meleeAttackBonus)}`
+                            } : {},
                             range: this.showAttackRanges ? 'close' : undefined
                         })
                     )
@@ -195,11 +195,11 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                         rangedAttackActions.push(
                             new Action(attack, actionType, {
                                 icon2: this.#getThrownIcon(),
-                                name:
-                                    attack.name +
-                                    (this.showAttackBonus
-                                        ? getBonusString(thrownAttackBonus)
-                                        : ''),
+                                name: attack.name,
+                                info1: this.showAttackBonus ? {
+                                    text: coreModule.api.Utils.getModifier(thrownAttackBonus),
+                                    title: `${game.i18n.localize("SHADOWDARK.item.effect.predefined_effect.rangedAttackBonus")}: ${coreModule.api.Utils.getModifier(thrownAttackBonus)}`
+                                } : {},
                                 range: this.showAttackRanges
                                     ? attack.system.range
                                     : undefined
@@ -216,11 +216,11 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
 
                     rangedAttackActions.push(
                         new Action(attack, actionType, {
-                            name:
-                                attack.name +
-                                (this.showAttackBonus
-                                    ? getBonusString(rangedAttackBonus)
-                                    : ''),
+                            name: attack.name,
+                            info1: this.showAttackBonus ? {
+                                text: coreModule.api.Utils.getModifier(rangedAttackBonus),
+                                title: `${game.i18n.localize("SHADOWDARK.item.effect.predefined_effect.rangedAttackBonus")} ${coreModule.api.Utils.getModifier(rangedAttackBonus)}`
+                            } : {},
                             range: this.showAttackRanges
                                 ? attack.system.range
                                 : undefined
@@ -254,22 +254,21 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
          */
         async #buildAbilities () {
             const actionType = 'ability'
-            const abilities = ['str', 'dex', 'con', 'int', 'wis', 'cha']
+            const abilities = CONFIG.SHADOWDARK.ABILITY_KEYS;
 
             const abilityActions = await Promise.all(
                 abilities.map(async (ability) => {
-                    const id = `${actionType}-${ability}`
-                    const name =
-                        coreModule.api.Utils.i18n(ABILITY[ability].name) +
-                        (this.showAbilityBonus && this.actor
-                            ? getBonusString(
-                                this.actor?.system.abilities[ability].mod
-                            )
-                            : '')
-
+                    const id = `${actionType}-${ability}`;
+                    const name = coreModule.api.Utils.i18n(CONFIG.SHADOWDARK.ABILITIES_LONG[ability]);
+                    const mod = this.actor?.system.abilities[ability].mod
+                    
                     return {
-                        id,
-                        name,
+                        id: `${actionType}-${ability}`,
+                        name: (this.abbreviateSkills) ? Utils.capitalize(ability) : name,
+                        info1: (this.actor && this.showAbilityBonus) ? {
+                            text: coreModule.api.Utils.getModifier(mod),
+                            title: `${game.i18n.localize("SHADOWDARK.class-ability.ability.check")}: ${coreModule.api.Utils.getModifier(mod)}`
+                        }: null,
                         system: { actionType, actionId: ability }
                     }
                 })
@@ -594,14 +593,11 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                 if (ranges.includes('close')) {
                     meleeAttackActions.push(
                         new Action(attack, 'npcAttack', {
-                            name:
-                                _toTitleCase(attack.name) +
-                                `${this.showAttackBonus
-                                    ? getBonusString(
-                                        attack.system.bonuses.attackBonus
-                                    )
-                                    : ''
-                                }`,
+                            name: _toTitleCase(attack.name),
+                            info1: this.showAttackBonus ? {
+                                text: coreModule.api.Utils.getModifier(attack.system.bonuses.attackBonus),
+                                title: `${game.i18n.localize("SHADOWDARK.item.npc_attack_bonus")} ${coreModule.api.Utils.getModifier(attack.system.bonuses.attackBonus)}`
+                            } : {},
                             range: this.showAttackRanges ? 'close' : undefined
                         })
                     )
@@ -614,18 +610,12 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                         rangedAttackActions.push(
                             new Action(attack, 'npcAttack', {
                                 icon2: this.#getThrownIcon(),
-                                name:
-                                    _toTitleCase(attack.name) +
-                                    `${this.showAttackBonus
-                                        ? getBonusString(
-                                            attack.system.bonuses
-                                                .attackBonus
-                                        )
-                                        : ''
-                                    }`,
-                                range: this.showAttackRanges
-                                    ? maxRange
-                                    : undefined
+                                name: _toTitleCase(attack.name),
+                                info1: this.showAttackBonus ? {
+                                    text: coreModule.api.Utils.getModifier(attack.system.bonuses.attackBonus),
+                                    title: `${game.i18n.localize("SHADOWDARK.item.npc_attack_bonus")} ${coreModule.api.Utils.getModifier(attack.system.bonuses.attackBonus)}`
+                                } : {},
+                                range: this.showAttackRanges ? maxRange : undefined
                             })
                         )
                         continue
@@ -634,14 +624,11 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                     const maxRange = ranges.includes('far') ? 'far' : 'near'
                     rangedAttackActions.push(
                         new Action(attack, 'npcAttack', {
-                            name:
-                                _toTitleCase(attack.name) +
-                                `${this.showAttackBonus
-                                    ? getBonusString(
-                                        attack.system.bonuses.attackBonus
-                                    )
-                                    : ''
-                                }`,
+                            name: _toTitleCase(attack.name),
+                            info1: this.showAttackBonus ? {
+                                text: coreModule.api.Utils.getModifier(attack.system.bonuses.attackBonus),
+                                title: `${game.i18n.localize("SHADOWDARK.item.npc_attack_bonus")} ${coreModule.api.Utils.getModifier(attack.system.bonuses.attackBonus)}`
+                            } : {},
                             range: this.showAttackRanges ? maxRange : undefined
                         })
                     )
@@ -711,11 +698,6 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
         }
     }
 
-    // Convert a numerical bonus into a string with the appropriate +/- sign.
-    function getBonusString (bonus) {
-        return ` (${bonus >= 0 ? '+' : ''}${bonus})`
-    }
-
     function _getRangeIcon (range) {
         const title = CONFIG.SHADOWDARK.RANGES[range] ?? ''
         const icon = ICON[range]
@@ -739,6 +721,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
             this.icon1 = _getRangeIcon(options?.range)
             this.icon2 = options?.icon2
             this.cssClass = options?.cssClass
+            this.info1 = options?.info1
             this.system = { actionType, actionId: item.id }
         }
     }

--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -48,8 +48,6 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
             if (this.actorType && !knownActors.includes(this.actorType)) return
 
             // Settings
-            this.showAttackBonus = Utils.getSetting('showAttackBonus')
-            this.showAbilityBonus = Utils.getSetting('showAbilityBonus')
             this.wandScrollIcon = Utils.getSetting('wandScrollIcon')
             this.hideLantern = Utils.getSetting('hideLantern')
             this.showAttackRanges = Utils.getSetting('showAttackRanges')
@@ -174,10 +172,10 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                     meleeAttackActions.push(
                         new Action(attack, actionType, {
                             name: attack.name,
-                            info1: this.showAttackBonus ? {
+                            info1: {
                                 text: coreModule.api.Utils.getModifier(meleeAttackBonus),
                                 title: `${game.i18n.localize("SHADOWDARK.item.effect.predefined_effect.meleeAttackBonus")}: ${coreModule.api.Utils.getModifier(meleeAttackBonus)}`
-                            } : {},
+                            },
                             range: this.showAttackRanges ? 'close' : undefined
                         })
                     )
@@ -196,10 +194,10 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                             new Action(attack, actionType, {
                                 icon2: this.#getThrownIcon(),
                                 name: attack.name,
-                                info1: this.showAttackBonus ? {
+                                info1: {
                                     text: coreModule.api.Utils.getModifier(thrownAttackBonus),
                                     title: `${game.i18n.localize("SHADOWDARK.item.effect.predefined_effect.rangedAttackBonus")}: ${coreModule.api.Utils.getModifier(thrownAttackBonus)}`
-                                } : {},
+                                },
                                 range: this.showAttackRanges
                                     ? attack.system.range
                                     : undefined
@@ -217,10 +215,10 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                     rangedAttackActions.push(
                         new Action(attack, actionType, {
                             name: attack.name,
-                            info1: this.showAttackBonus ? {
+                            info1: {
                                 text: coreModule.api.Utils.getModifier(rangedAttackBonus),
                                 title: `${game.i18n.localize("SHADOWDARK.item.effect.predefined_effect.rangedAttackBonus")} ${coreModule.api.Utils.getModifier(rangedAttackBonus)}`
-                            } : {},
+                            },
                             range: this.showAttackRanges
                                 ? attack.system.range
                                 : undefined
@@ -265,7 +263,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                     return {
                         id: `${actionType}-${ability}`,
                         name: (this.abbreviateSkills) ? Utils.capitalize(ability) : name,
-                        info1: (this.actor && this.showAbilityBonus) ? {
+                        info1: (this.actor) ? {
                             text: coreModule.api.Utils.getModifier(mod),
                             title: `${game.i18n.localize("SHADOWDARK.class-ability.ability.check")}: ${coreModule.api.Utils.getModifier(mod)}`
                         }: null,
@@ -594,10 +592,10 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                     meleeAttackActions.push(
                         new Action(attack, 'npcAttack', {
                             name: _toTitleCase(attack.name),
-                            info1: this.showAttackBonus ? {
+                            info1: {
                                 text: coreModule.api.Utils.getModifier(attack.system.bonuses.attackBonus),
-                                title: `${game.i18n.localize("SHADOWDARK.item.npc_attack_bonus")} ${coreModule.api.Utils.getModifier(attack.system.bonuses.attackBonus)}`
-                            } : {},
+                                title: game.i18n.localize("SHADOWDARK.item.npc_attack_bonus")
+                            },
                             range: this.showAttackRanges ? 'close' : undefined
                         })
                     )
@@ -611,10 +609,10 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                             new Action(attack, 'npcAttack', {
                                 icon2: this.#getThrownIcon(),
                                 name: _toTitleCase(attack.name),
-                                info1: this.showAttackBonus ? {
+                                info1: {
                                     text: coreModule.api.Utils.getModifier(attack.system.bonuses.attackBonus),
-                                    title: `${game.i18n.localize("SHADOWDARK.item.npc_attack_bonus")} ${coreModule.api.Utils.getModifier(attack.system.bonuses.attackBonus)}`
-                                } : {},
+                                    title: game.i18n.localize("SHADOWDARK.item.npc_attack_bonus")
+                                },
                                 range: this.showAttackRanges ? maxRange : undefined
                             })
                         )
@@ -625,10 +623,10 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                     rangedAttackActions.push(
                         new Action(attack, 'npcAttack', {
                             name: _toTitleCase(attack.name),
-                            info1: this.showAttackBonus ? {
+                            info1: {
                                 text: coreModule.api.Utils.getModifier(attack.system.bonuses.attackBonus),
-                                title: `${game.i18n.localize("SHADOWDARK.item.npc_attack_bonus")} ${coreModule.api.Utils.getModifier(attack.system.bonuses.attackBonus)}`
-                            } : {},
+                                title: game.i18n.localize("SHADOWDARK.item.npc_attack_bonus")
+                            },
                             range: this.showAttackRanges ? maxRange : undefined
                         })
                     )

--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -591,7 +591,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                 if (ranges.includes('close')) {
                     meleeAttackActions.push(
                         new Action(attack, 'npcAttack', {
-                            name: _toTitleCase(attack.name),
+                            name: Utils.capitalize(attack.name),
                             info1: {
                                 text: coreModule.api.Utils.getModifier(attack.system.bonuses.attackBonus),
                                 title: game.i18n.localize("SHADOWDARK.item.npc_attack_bonus")
@@ -608,7 +608,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                         rangedAttackActions.push(
                             new Action(attack, 'npcAttack', {
                                 icon2: this.#getThrownIcon(),
-                                name: _toTitleCase(attack.name),
+                                name: Utils.capitalize(attack.name),
                                 info1: {
                                     text: coreModule.api.Utils.getModifier(attack.system.bonuses.attackBonus),
                                     title: game.i18n.localize("SHADOWDARK.item.npc_attack_bonus")
@@ -622,7 +622,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                     const maxRange = ranges.includes('far') ? 'far' : 'near'
                     rangedAttackActions.push(
                         new Action(attack, 'npcAttack', {
-                            name: _toTitleCase(attack.name),
+                            name: Utils.capitalize(attack.name),
                             info1: {
                                 text: coreModule.api.Utils.getModifier(attack.system.bonuses.attackBonus),
                                 title: game.i18n.localize("SHADOWDARK.item.npc_attack_bonus")
@@ -700,13 +700,6 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
         const title = CONFIG.SHADOWDARK.RANGES[range] ?? ''
         const icon = ICON[range]
         return (icon) ? `<i class="${icon}" title="${title}"></i>` : ''
-    }
-
-    // convert a string to titlecase (useful for monsters from monster importer)
-    function _toTitleCase (str) {
-        return str.replace(/\w\S*/g, function (txt) {
-            return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
-        })
     }
 
     class Action {

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -52,15 +52,6 @@ export const GROUP = {
     talents: { id: 'talents', name: 'SHADOWDARK.class.talents.label', type: 'system' }
 }
 
-export const ABILITY = {
-    str: { name: 'SHADOWDARK.ability_strength' },
-    dex: { name: 'SHADOWDARK.ability_dexterity' },
-    con: { name: 'SHADOWDARK.ability_constitution' },
-    int: { name: 'SHADOWDARK.ability_intelligence' },
-    wis: { name: 'SHADOWDARK.ability_wisdom' },
-    cha: { name: 'SHADOWDARK.ability_charisma' }
-}
-
 export const ICON = {
     thrown: 'fa-solid fa-share',
     wand: 'fa-solid fa-wand-magic-sparkles',

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -7,38 +7,6 @@ import { MODULE } from './constants.js'
  * @param {function} coreUpdate Token Action HUD Core update function
  */
 export function register (coreUpdate) {
-    game.settings.register(MODULE.ID, 'showAttackBonus', {
-        name: game.i18n.localize(
-            'tokenActionHud.shadowdark.setting.showAttackBonus.name'
-        ),
-        hint: game.i18n.localize(
-            'tokenActionHud.shadowdark.setting.showAttackBonus.hint'
-        ),
-        scope: 'client',
-        config: true,
-        type: Boolean,
-        default: true,
-        onChange: (value) => {
-            coreUpdate(value)
-        }
-    })
-
-    game.settings.register(MODULE.ID, 'showAbilityBonus', {
-        name: game.i18n.localize(
-            'tokenActionHud.shadowdark.setting.showAbilityBonus.name'
-        ),
-        hint: game.i18n.localize(
-            'tokenActionHud.shadowdark.setting.showAbilityBonus.hint'
-        ),
-        scope: 'client',
-        config: true,
-        type: Boolean,
-        default: true,
-        onChange: (value) => {
-            coreUpdate(value)
-        }
-    })
-
     game.settings.register(MODULE.ID, 'showAttackRanges', {
         name: game.i18n.localize(
             'tokenActionHud.shadowdark.setting.showAttackRanges.name'


### PR DESCRIPTION
This PR:
* Improves the display of attack and ability modifiers by using the `info1` field to:
  * Display the modifier as a small superscript next to the title.
  * Replace `getBonusString` with TAH Core's `Utils.getModifier`
  * Add a `title` tooltip to the `info1` by using a relevant string from the Shadowdark system.
* Removes the `showAttackBonus` and `showAbilityBonus` settings (unless these should still be optional)
* Replaces remaining `_toTitleCase` calls with TAH Core's `Utils.capitalize`

Sample:
![image](https://github.com/user-attachments/assets/d6388625-a826-4a20-afbb-7a8b74962ddd)

Closes #59 